### PR TITLE
Specify HTML encoding charset explicitly

### DIFF
--- a/index.html
+++ b/index.html
@@ -1,6 +1,7 @@
 <!DOCTYPE html>
 
 <head>
+  <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1, minimal-ui">
   <title>Chat GPT Simple</title>
   <link rel="stylesheet" href="./main.css">


### PR DESCRIPTION
Browsers in Windows platform will specify charset based on its location, causing garbled emoji.

For example: Windows in China will specify GBK/GB2312 as its default charset.
![image](https://user-images.githubusercontent.com/26623948/227158226-2b396bb1-7487-4e43-9794-556985d23462.png)